### PR TITLE
Glance Image copying solved

### DIFF
--- a/ansible/micromosler.yml
+++ b/ansible/micromosler.yml
@@ -47,8 +47,15 @@
     - name: Running the openstack helper
       shell: /root/bin/openstack_helper.sh  2>/tmp/oserr >/tmp/osout
 
+    - name: Removing any old image from Glance
+      shell: . /root/.keystonerc && (glance image-list | awk '/ {{ item }} /{print $2}' | while read img; do glance image-delete $img; done)
+      with_items:
+        - project-computenode-stable 
+        - project-loginnode-stable
+        - topolino-q-stable
+
     - name: Adding the images to Glance
-      shell: . /root/.keystonerc && glance --os-image-api-version 1 image-create --location {{ mosler_images_url }}/{{ item }} --disk-format qcow2 --container-format bare  --name "project-computenode-stable" --is-public True
+      shell: . /root/.keystonerc && glance image-create --copy-from {{ mosler_images_url }}/{{ item }} --disk-format qcow2 --container-format bare  --name "{{ item }}" --is-public True
       with_items:
         - project-computenode-stable 
         - project-loginnode-stable
@@ -60,7 +67,6 @@
     #     - project-computenode-stable 
     #     - project-loginnode-stable
     #     - topolino-q-stable
-
 
 - name: OpenStack networking
   hosts: networking-node

--- a/ansible/micromosler.yml
+++ b/ansible/micromosler.yml
@@ -48,7 +48,7 @@
       shell: /root/bin/openstack_helper.sh  2>/tmp/oserr >/tmp/osout
 
     - name: Adding the images to Glance
-      shell: . /root/.keystonerc && glance image-create --file /tmp/mosler-images/{{ item }} --disk-format qcow2 --container-format bare  --name "project-computenode-stable" --is-public True
+      shell: . /root/.keystonerc && glance --os-image-api-version 1 image-create --location {{ mosler_images_url }}/{{ item }} --disk-format qcow2 --container-format bare  --name "project-computenode-stable" --is-public True
       with_items:
         - project-computenode-stable 
         - project-loginnode-stable

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -87,13 +87,13 @@
         - /tmp/misc/mosler-dashboard-2-5.i386.rpm
         - /tmp/misc/nginx-1.8.1-1.el6.ngx.x86_64.rpm
    
-    - file: path=/tmp/mosler-images/ state=directory
-    - name: Copying mosler images
-      copy: src={{ mosler_images }}/{{ item }} dest=/tmp/mosler-images/
-      with_items:
-        - project-computenode-stable 
-        - project-loginnode-stable
-        - topolino-q-stable
+    # - file: path=/tmp/mosler-images/ state=directory
+    # - name: Copying mosler images
+    #   copy: src={{ mosler_images }}/{{ item }} dest=/tmp/mosler-images/
+    #   with_items:
+    #     - project-computenode-stable 
+    #     - project-loginnode-stable
+    #     - topolino-q-stable
         
 - name: Upgrade all packages
   hosts: all

--- a/provision.sh
+++ b/provision.sh
@@ -71,6 +71,7 @@ mosler_images=${MOSLER_IMAGES}
 mosler_images_url=http://10.254.0.1:$((PORT+1))
 ENDINVENTORY
 
+[ $VERBOSE = "yes" ] && echo "Starting the Mosler Images server [in ${MOSLER_IMAGES}]"
 pushd ${MOSLER_IMAGES}
 python -m SimpleHTTPServer $((PORT+1)) &
 FILE_SERVER=$!
@@ -88,4 +89,5 @@ ANSIBLE_CONFIG=${ANSIBLE_CFG} ansible-playbook -s ./ansible/micromosler.yml
 # Note: config file overwritten by ANSIBLE_CFG env variable
 # Ansible-playbook options: http://linux.die.net/man/1/ansible-playbook
 
+[ $VERBOSE = "yes" ] && echo "Killing the Mosler Images server [PID: ${FILE_SERVER}]"
 kill ${FILE_SERVER}

--- a/provision.sh
+++ b/provision.sh
@@ -68,7 +68,13 @@ tl_home=${TL_HOME}
 mosler_home=${MOSLER_HOME}
 mosler_misc=${MOSLER_MISC}
 mosler_images=${MOSLER_IMAGES}
+mosler_images_url=http://10.254.0.1:$((PORT+1))
 ENDINVENTORY
+
+pushd ${MOSLER_IMAGES}
+python -m SimpleHTTPServer $((PORT+1)) &
+FILE_SERVER=$!
+popd
 
 # Aaaaannndddd....cue music!
 if [ $PACKAGES = "yes" ]; then
@@ -81,3 +87,5 @@ fi
 ANSIBLE_CONFIG=${ANSIBLE_CFG} ansible-playbook -s ./ansible/micromosler.yml
 # Note: config file overwritten by ANSIBLE_CFG env variable
 # Ansible-playbook options: http://linux.die.net/man/1/ansible-playbook
+
+kill ${FILE_SERVER}


### PR DESCRIPTION
We start a SimpleHTTPServer, serving files from the ${MOSLER_IMAGES} folder,
and we tell glance to use the --copy-from URL flag.

We added a step that removes any previously known images.

Important NOTE: Glance CLI returns immediately, but the downloading continues. We just hope that it is completed by the time we kill the SimpleHTTPServer. Alternatively, check that any ongoing download are completed before we kill it (which is not yet done)
